### PR TITLE
remove one notify_unless call

### DIFF
--- a/src/join_handle.rs
+++ b/src/join_handle.rs
@@ -206,7 +206,9 @@ impl<R, T> Future for JoinHandle<R, T> {
                     // completed or closed just before registration so we need to check for that.
                     state = (*header).state.load(Ordering::Acquire);
 
-                    // If the task has been closed, notify the awaiter and return `None`.
+                    // If the task has been closed, return `None`. We do not need to notify the
+                    // awaiter here, since we have replaced the waker above, and the executor can
+                    // only set it back to None.
                     if state & CLOSED != 0 {
                         return Poll::Ready(None);
                     }

--- a/src/join_handle.rs
+++ b/src/join_handle.rs
@@ -208,7 +208,7 @@ impl<R, T> Future for JoinHandle<R, T> {
 
                     // If the task has been closed, return `None`. We do not need to notify the
                     // awaiter here, since we have replaced the waker above, and the executor can
-                    // only set it back to None.
+                    // only set it back to `None`.
                     if state & CLOSED != 0 {
                         return Poll::Ready(None);
                     }

--- a/src/join_handle.rs
+++ b/src/join_handle.rs
@@ -208,9 +208,6 @@ impl<R, T> Future for JoinHandle<R, T> {
 
                     // If the task has been closed, notify the awaiter and return `None`.
                     if state & CLOSED != 0 {
-                        // Even though the awaiter is most likely the current task, it could also
-                        // be another task.
-                        (*header).notify_unless(cx.waker());
                         return Poll::Ready(None);
                     }
 


### PR DESCRIPTION
`Header::awaiter` can only be changed with `Header::swap_awaiter`, which only be called in three places.
`swap_awaiter(None)` in two places, and one in function `JoinHandle::poll` at line 202. since `JoinHandle::poll` will not called concurrently, at line 211 we can conclude that `Header::awaiter` must be `cx.waker()` (set at line 202) or `None`(set by other thread). so call `notify_unless` will have no effects, and can be removed.