### PR TITLE
Add no-std category

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/async-rs/async-task"
 documentation = "https://docs.rs/async-task"
 description = "Task abstraction for building executors"
 keywords = ["futures", "task", "executor", "spawn"]
-categories = ["asynchronous", "concurrency"]
+categories = ["asynchronous", "concurrency", "no-std"]
 readme = "README.md"
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Now that the crate is `#[no_std]`, we can mark it as such.