### PR TITLE
`RawTask` refactoring

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -128,7 +128,7 @@ impl Header {
 
         // Put the waker into the awaiter field.
         unsafe {
-            abort_on_panic(|| self.awaiter.get().write(Some(waker.clone())));
+            abort_on_panic(|| *(self.awaiter.get()) = Some(waker.clone()));
         }
 
         // This variable will contain the newly registered waker if a notification comes in before

--- a/src/join_handle.rs
+++ b/src/join_handle.rs
@@ -84,12 +84,9 @@ impl<R, T> JoinHandle<R, T> {
 
     /// Returns a reference to the tag stored inside the task.
     pub fn tag(&self) -> &T {
-        let offset = Header::offset_tag::<T>();
-        let ptr = self.raw_task.as_ptr();
-
         unsafe {
-            let raw = (ptr as *mut u8).add(offset) as *const T;
-            &*raw
+            let header = self.raw_task.as_ptr() as *const Header;
+            &*Header::tag_ptr::<T>(header)
         }
     }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -48,14 +48,14 @@ pub(crate) struct RawTask<F, R, S, T> {
     tag: T,
     /// The schedule function.
     schedule: S,
-    /// The future.
+    /// The future and after its completion the future's output.
     fut_then_output: FutThenOutput<F, R>,
 }
 
 enum FutThenOutput<F, R> {
     /// The future.
     Future(F),
-    /// The output of the future.
+    /// The future's output.
     Output(R),
 }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -39,7 +39,7 @@ pub(crate) struct TaskVTable {
     pub(crate) clone_waker: unsafe fn(ptr: *const ()) -> RawWaker,
 }
 
-/// Raw pointers to the fields inside a task.
+/// The raw in-memory representation of a task.
 #[repr(C)]
 pub(crate) struct RawTask<F, R, S, T> {
     /// The task header.
@@ -48,7 +48,7 @@ pub(crate) struct RawTask<F, R, S, T> {
     tag: T,
     /// The schedule function.
     schedule: S,
-    /// The future and after its completion the future's output.
+    /// The future and, after its completion, the future's output.
     fut_then_output: FutThenOutput<F, R>,
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,3 @@
-use core::alloc::Layout;
 use core::mem;
 
 /// Aborts the process.
@@ -34,31 +33,4 @@ pub(crate) fn abort_on_panic<T>(f: impl FnOnce() -> T) -> T {
     let t = f();
     mem::forget(bomb);
     t
-}
-
-/// Returns the layout for `a` followed by `b` and the offset of `b`.
-///
-/// This function was adapted from the currently unstable `Layout::extend()`:
-/// https://doc.rust-lang.org/nightly/std/alloc/struct.Layout.html#method.extend
-#[inline]
-pub(crate) fn extend(a: Layout, b: Layout) -> (Layout, usize) {
-    let new_align = a.align().max(b.align());
-    let pad = padding_needed_for(a, b.align());
-
-    let offset = a.size().checked_add(pad).unwrap();
-    let new_size = offset.checked_add(b.size()).unwrap();
-
-    let layout = Layout::from_size_align(new_size, new_align).unwrap();
-    (layout, offset)
-}
-
-/// Returns the padding after `layout` that aligns the following address to `align`.
-///
-/// This function was adapted from the currently unstable `Layout::padding_needed_for()`:
-/// https://doc.rust-lang.org/nightly/std/alloc/struct.Layout.html#method.padding_needed_for
-#[inline]
-pub(crate) fn padding_needed_for(layout: Layout, align: usize) -> usize {
-    let len = layout.size();
-    let len_rounded_up = len.wrapping_add(align).wrapping_sub(1) & !align.wrapping_sub(1);
-    len_rounded_up.wrapping_sub(len)
 }


### PR DESCRIPTION
Looking through the code of this crate, I've found the the `raw` module to be quite obtuse and unnecessarily so.

Basically, what this PR does is refactor the `raw` module and its explicit and implicit dependencies in the rest of the crate for greater clarity, and in the process achieves a net reduction of approximately 100 lines of code by removing most of the manual memory layout fiddling.

At its core, `RawTask` is now no longer a collection of pointers into a manually allocated and otherwise undifferentiated blob of memory on the heap.
Instead, it is now a `#[repr(C)]` struct describing the actual memory layout of a task.
I assume, this was originally done because `union`s with non-Copy fields are unstable, but I believe the small overhead of using a (tagged) `enum` for the Future/Output is outweighed by the clearer and more concise code.
Either way, using `async-task`'s own benchmark suite, I found no performance difference between either variant.
Once non-Copy `unions` become stable, the current code can be easily refactored to use a `union` instead of an `enum`.
