### PR TITLE
Switch CI to stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
   - windows
 
-rust: nightly
+rust: stable
 
 env:
   - RUSTFLAGS="-D warnings"


### PR DESCRIPTION
Switch our CI runners to use stable instead of nightly Rust.